### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,6 @@ Lando offers a configurable [recipe](https://docs.lando.dev/config/recipes.html)
 * Configurable `webroot`
 * Configurable web server (`apache` or `nginx`)
 * Configurable database backend (`mariadb`, `mysql`, or `postgres`)
-* Configurable `composer`
+* [Configurable `composer`](https://docs.lando.dev/php/config.html#installing-composer)
 * Configurable caching backend (`redis` or `memcached`)
 * `xdebug`


### PR DESCRIPTION
I had issues finding the the correct place to configure composer. (v1 → v2)
Don't know if current change would make it easier to find it.

Maybe also just change the default composer? (at recipe/lamp?)
![](https://i.imgur.com/U3qNFPL.png)
https://blog.packagist.com/deprecating-composer-1-support/

Feel free to decline and propose another solution :)


(also did not find it with the search, had to get back to google to find the link)
![image](https://user-images.githubusercontent.com/5683799/176857549-8644fc81-2ffa-4078-9ff6-e088743ac0bc.png)
